### PR TITLE
Made php::pear configurable

### DIFF
--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -19,8 +19,9 @@
 #   Default: true
 #
 class php::pear (
-  $package = "php-pear",
-  $install_package = true
+  $package         = 'php-pear',
+  $install_package = true,
+  $path            = '/usr/bin:/usr/sbin:/bin:/sbin',
   ) {
 
   include php

--- a/manifests/pear/config.pp
+++ b/manifests/pear/config.pp
@@ -11,8 +11,9 @@ define php::pear::config ($value) {
 
   exec { "pear-config-set-${name}":
       command => "pear config-set ${name} ${value}",
+      path    => $php::pear::path,
       unless  => "pear config-get ${name} | grep ${value}",
-      require => Package['php-pear'],
+      require => Package[$php::pear::package],
   }
 
 }

--- a/manifests/pear/module.pp
+++ b/manifests/pear/module.pp
@@ -11,6 +11,10 @@
 #   (default="stable") - Define which preferred state to use when installing
 #   Pear modules via pear via command line (when use_package=no)
 #
+# [*alldeps*]
+#   (default="false") - Define if all the available (optional) modules should
+#   be installed. (when use_package=no)
+#
 # Usage:
 # php::pear::module { packagename: }
 # Example:
@@ -19,7 +23,9 @@
 define php::pear::module ( 
   $service         = $php::service,
   $use_package     = 'yes',
-  $preferred_state = 'stable') {
+  $preferred_state = 'stable',
+  $alldeps         = false,
+  ) {
 
   include php::pear
 
@@ -37,10 +43,13 @@ define php::pear::module (
     }
     default: {
       exec { "pear-${name}":
-        command => "pear -d preferred_state=${preferred_state} install ${name}",
+        command => $alldeps ? {
+          true  => "pear -d preferred_state=${preferred_state} install --alldeps ${name}",
+          false => "pear -d preferred_state=${preferred_state} install ${name}",
+        },
         unless  => "pear info ${name}",
-        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-        require => Package['php-pear'],
+        path    => $php::pear::path,
+        require => Package[$php::pear::package],
       }
     }
   } # End Case


### PR DESCRIPTION
Zend Server provides PEAR and PHP in the same Debian package (which isn't called php-pear). Therefore, I first added functionality to provide an alternative name, after that I added functionality to simply disable the installation of the package - to prevent the error below:

err: Could not retrieve catalog from remote server: Error 400 on SERVER: Puppet::Parser::AST::Resource failed with error ArgumentError: Cannot alias Package[php-pear] to ["zend-server-php-5.4"] at /etc/puppet/environments/development/modules/php/manifests/pear.pp:17; resource ["Package", "zend-server-php-5.4"] already defined at /etc/puppet/environments/development/modules/php/manifests/init.pp:213 at /etc/puppet/environments/development/modules/php/manifests/pear.pp:17 on node dev.enriserestfulskeletonapplication.dev
