### PR TITLE
Allow custom config file for pecl modules.

### DIFF
--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -42,7 +42,8 @@ define php::pecl::module (
   $preferred_state     = 'stable',
   $auto_answer         = '\\n',
   $ensure              = present,
-  $verbose             = false ) {
+  $verbose             = false,
+  $config_file         = $php::config_file) {
 
   include php
   include php::devel
@@ -90,6 +91,7 @@ define php::pecl::module (
             value  => "${name}.so",
             ensure => $ensure,
             notify => $manage_service_autorestart,
+            target => $config_file,
         }
       }
     }


### PR DESCRIPTION
Hi, i think it makes sense to use multiple php config files. Especially one for each pecl module.
