### PR TITLE
Document usage with nginx instead of apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           audit_only => true
         }
 
+* Install php in an nginx environment
+
+        class { 'php':
+          service => 'nginx'
+        }
+
 ## USAGE - Module installation
 
 * Install a new module


### PR DESCRIPTION
I kept getting the following error when I tried to install modules: `Error: Failed to apply catalog: Could not find dependent Service[apache2] for Package[PhpModule_common]`
Until I realised it wasn't so much because of a failed dependancy rather than a wrong notification. Thus I believe it is worth documenting since a lot of people now use nginx instead of apache, and don't want to have to install the later.
