### PR TITLE
changed inheritance of param from params_lookup to old style

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -1,13 +1,12 @@
 define php::ini (
-    $value    = '',
-    $template = 'extra-ini.erb',
-    $target   = 'extra.ini',
-    $service  = $php::service
+    $value       = '',
+    $template    = 'extra-ini.erb',
+    $target      = 'extra.ini',
+    $service     = $php::service,
+    $config_dir  = $php::params::config_dir
 ) {
 
   include php
-
-  $config_dir = params_lookup( 'config_dir' )
 
   file { "${config_dir}/conf.d/${target}":
     ensure  => 'present',


### PR DESCRIPTION
Dear Alessandro,

on our puppet system
Master:
Debian Squeeze
Puppet 3.0.1

the params_lookup for config_dir was not working as expected. 
The oldschool style is properly working.
Maybe you can have a look at it.
Bets Regards
Arne-Kristian
