### PR TITLE
Change official git repo url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Made by ALessandro Franceschi / Lab42
 
 Official site: http://www.example42.com
 
-Official git repository: http://github.com/lermit/puppet-php
+Official git repository: http://github.com/example42/puppet-php
 
 Released under the terms of Apache 2 License.
 


### PR DESCRIPTION
The README points to another repo as the official git repository, but that one has not been updated for more than a year, so I guess this is not valid anymore.

So let's remove the confusion for people like me :smile: 
