### PR TITLE
Proposal: Add support for sapi

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -43,7 +43,8 @@ define php::ini (
       ensure  => 'present',
       content => template("php/${template}"),
       require => Package['php'],
-    }->
+      before  => File["${config_dir}/cli/conf.d/${target}"],
+    }
 
     file { "${config_dir}/cli/conf.d/${target}":
       ensure  => 'present',


### PR DESCRIPTION
This probably fixes issue #45

Some info on this: 

In old configurations php folder has structure of: 

```
/etc/php5/
     /    \     \ 
apache2   cli   conf.d
   |        |
conf.d     conf.d 
```

Where  `conf.d` is a symlink for all folders. In this config model when adding a config for any sapi it would be applied to all sapis. 

PHP changed since 5.5  if I am not mistaken. 

```
/etc/php5/
     /    \   
apache2   cli
   |        |
conf.d     conf.d 
```

Now `conf.d` is not a symlink and sapis can be configured separately. 

The provided pull requests solved the confusion for both of the aspects giving option to the user to specify sapis or default to both (as of schema 1 above).
