### PR TITLE
Autorestart after pecl extension creation

### DIFF
--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -111,6 +111,7 @@ define php::pecl::module (
         logoutput => $pecl_exec_logoutput,
         path      => $path,
         require   => [ Class['php::pear'], Class['php::devel']],
+        notify    => $manage_service_autorestart,
       }
       if $php::bool_augeas == true {
         php::augeas { "augeas-${name}":


### PR DESCRIPTION
Scenario: After your first puppet run you notice that the phing install command has returned 255 exit code instead of 0, so puppet marks it as failed, and because other pecl modules depend on it, it skips installing them. On your next run everything works fine, phing and the modules install but the httpd service does not get restarted.

The fix aims to notify the service in the above scenario.
