### PR TITLE
Fixed ability to detect PECL install failures

### DIFF
--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -83,8 +83,13 @@ define php::pecl::module (
       }
     }
     default: {
-      if $ensure and !defined(Package['libpcre3-dev']) {
-        package { "libpcre3-dev": }
+        $pcre_dev_package_name = $::operatingsystem ? {
+          ubuntu  => "libpcre3-dev",
+          debian  => "libpcre3-dev",
+          default => "pcre3-devel",
+        }
+      if $ensure and !defined(Package[$pcre_dev_package_name]) {
+        package { $pcre_dev_package_name : }
       }
 
       $bool_verbose = any2bool($verbose)
@@ -111,7 +116,7 @@ define php::pecl::module (
       }
 
       $pecl_exec_require = $ensure ? {
-        present => [ Class['php::pear'], Class['php::devel'], Package['libpcre3-dev']],
+        present => [ Class['php::pear'], Class['php::devel'], Package[$pcre_dev_package_name]],
         absent  => [ Class['php::pear'], Class['php::devel']]
       }
 


### PR DESCRIPTION
## Fixed ability to detect PECL install failures
- `peck install` wasn't providing proper exit codes. Worked around this by detecting the package after the installation.
- Also added dependancy installing a library that at least 2 common PECL packages require for building
