### PR TITLE
add links => follow to source.dir ressource, cause of the possibility th...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,6 +264,7 @@ class php (
       require => Package['php'],
       source  => $php::source_dir,
       recurse => true,
+      links   => follow,
       purge   => $php::bool_source_dir_purge,
       force   => $php::bool_source_dir_purge,
       replace => $php::manage_file_replace,


### PR DESCRIPTION
add this to the source.dir ressource, cause of the possibility that source.dir is a symlink, if this is missing, source.dir will never be purged.
