### PR TITLE
iconv causes exec unless to always return 0

### DIFF
--- a/manifests/pear/module.pp
+++ b/manifests/pear/module.pp
@@ -59,13 +59,13 @@ define php::pear::module (
   }
 
   $pear_exec_unless = $ensure ? {
-    present => "pear info ${pear_source} | iconv -c",
+    present => "pear info ${pear_source}",
     absent  => undef
   }
 
   $pear_exec_onlyif = $ensure ? {
     present => undef,
-    absent  => "pear info ${pear_source} | iconv -c",
+    absent  => "pear info ${pear_source}",
   }
 
   $real_service = $service ? {


### PR DESCRIPTION
The pipe to iconv causes the unless statement to always return 0, which means the pear package is not being installed.

Example of the issue:

Mainfest:

```
php::pear::module { "Net_GeoIP": use_package => 'no' }
```

Testing:

```
server:~ # pear info pear.php.net/Net_GeoIP | iconv -c
No information found for `pear.php.net/Net_GeoIP'
server:~ # echo $?
0
server:~ # pear info pear.php.net/Net_GeoIP
No information found for `pear.php.net/Net_GeoIP'
server:~ # echo $?
1
```

Before this change: Net_GeoIP is never installed
After this change: Net_GeoIP is installed

OS:

```
# lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.1 LTS
Release:    14.04
Codename:   trusty
```
