### PR TITLE
Fix issues with `pear info` and encodings

### DIFF
--- a/manifests/pear/module.pp
+++ b/manifests/pear/module.pp
@@ -59,13 +59,13 @@ define php::pear::module (
   }
 
   $pear_exec_unless = $ensure ? {
-    present => "pear info ${pear_source}",
+    present => "pear shell-test ${pear_source} > 0",
     absent  => undef
   }
 
   $pear_exec_onlyif = $ensure ? {
     present => undef,
-    absent  => "pear info ${pear_source}",
+    absent  => "pear shell-test ${pear_source} > 0",
   }
 
   $real_service = $service ? {

--- a/spec/defines/php_pear_module_spec.rb
+++ b/spec/defines/php_pear_module_spec.rb
@@ -39,7 +39,7 @@ describe 'php::pear::module' do
     it 'should install pear module with exec commands' do
       should contain_exec('pear-Crypt-CHAP').with(
         'command' => 'pear -d preferred_state=stable install  pear.php.net/Crypt-CHAP',
-        'unless'  => 'pear info pear.php.net/Crypt-CHAP | iconv -c'
+        'unless'  => 'pear shell-test pear.php.net/Crypt-CHAP > 0'
       )
     end
   end


### PR DESCRIPTION
Fixes #68 without using iconv as per #78. Perhaps a better solution than #73 (which I only found after writing this) since it uses pear's built-in installation check rather than relying on `pear info`. As someone having the issues identified in #68, I can confirm this works properly with drush.