### PR TITLE
Feature - Package install options

### DIFF
--- a/manifests/devel.pp
+++ b/manifests/devel.pp
@@ -7,7 +7,8 @@ class php::devel {
   if $php::package_devel != ''
   and ! defined(Package[$php::package_devel]) {
     package { $php::package_devel :
-      ensure => $php::manage_package,
+      ensure          => $php::manage_package,
+      install_options => $php::install_options,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,9 @@
 #   For example, adding a `--enablerepo` option to Yum or specifying a
 #   `--no-install-recommends` option during an Apt install.
 #   NOTE: The `install_options` package class parameter was added for Yum/Apt
-#   in Puppet 3.6
+#   in Puppet 3.6. Its format of the option is an array, where each option in
+#   the array is either a string or a hash.
+#   Example: `install_options => ['-y', {'--enablerepo' => 'remi-php55'}]`
 #
 # [*absent*]
 #   Set to 'true' to remove package(s) installed by module

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,14 @@
 #   Note that if the argument absent (see below) is set to true, the
 #   package is removed, whatever the value of version parameter.
 #
+# [*install_options*]
+#   The package install options to be passed to the package manager. Useful for
+#   setting advanced/custom options during package install/update.
+#   For example, adding a `--enablerepo` option to Yum or specifying a
+#   `--no-install-recommends` option during an Apt install.
+#   NOTE: The `install_options` package class parameter was added for Yum/Apt
+#   in Puppet 3.6
+#
 # [*absent*]
 #   Set to 'true' to remove package(s) installed by module
 #   Can be defined also by the (top scope) variable $php_absent
@@ -151,6 +159,7 @@ class php (
   $augeas              = params_lookup( 'augeas' ),
   $options             = params_lookup( 'options' ),
   $version             = params_lookup( 'version' ),
+  $install_options     = params_lookup( 'install_options' ),
   $absent              = params_lookup( 'absent' ),
   $monitor             = params_lookup( 'monitor' , 'global' ),
   $monitor_tool        = params_lookup( 'monitor_tool' , 'global' ),
@@ -238,8 +247,9 @@ class php (
 
   ### Managed resources
   package { 'php':
-    ensure => $php::manage_package,
-    name   => $php::package,
+    ensure          => $php::manage_package,
+    name            => $php::package,
+    install_options => $php::install_options,
   }
 
   file { 'php.conf':

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -47,7 +47,7 @@
 #
 define php::module (
   $version             = 'present',
-  $install_options     = [],
+  $install_options     = '',
   $service_autorestart = '',
   $module_prefix       = '',
   $absent              = ''
@@ -76,8 +76,8 @@ define php::module (
   }
 
   $real_install_options = $install_options ? {
-    []      => $php::install_options,
-    default => $install_options,
+    ''      => $php::install_options,
+    default => [],
   }
 
   $real_install_package = "${real_module_prefix}${name}"

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -26,6 +26,9 @@
 # [*module_prefix*]
 #   If package name prefix isn't standard.
 #
+# [*install_options*]
+#   An array of package manager install options. See $php::install_options
+#
 # == Examples
 # php::module { 'gd': }
 #
@@ -44,6 +47,7 @@
 #
 define php::module (
   $version             = 'present',
+  $install_options     = [],
   $service_autorestart = '',
   $module_prefix       = '',
   $absent              = ''
@@ -71,14 +75,20 @@ define php::module (
     default => $module_prefix,
   }
 
+  $real_install_options = $install_options ? {
+    []      => $php::install_options,
+    default => $install_options,
+  }
+
   $real_install_package = "${real_module_prefix}${name}"
 
   if defined(Package[$real_install_package]) == false {
     package { "PhpModule_${name}":
-      ensure  => $real_version,
-      name    => $real_install_package,
-      notify  => $real_service_autorestart,
-      require => Package['php'],
+      ensure          => $real_version,
+      name            => $real_install_package,
+      notify          => $real_service_autorestart,
+      install_options => $real_install_options,
+      require         => Package['php'],
     }
   }
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -47,7 +47,7 @@
 #
 define php::module (
   $version             = 'present',
-  $install_options     = '',
+  $install_options     = [],
   $service_autorestart = '',
   $module_prefix       = '',
   $absent              = ''
@@ -77,7 +77,7 @@ define php::module (
 
   $real_install_options = $install_options ? {
     ''      => $php::install_options,
-    default => [],
+    default => $install_options,
   }
 
   $real_install_package = "${real_module_prefix}${name}"

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -27,14 +27,14 @@
 class php::pear (
   $package         = $php::package_pear,
   $install_package = true,
-  $install_options = '',
+  $install_options = [],
   $version         = 'present',
   $path            = '/usr/bin:/usr/sbin:/bin:/sbin'
   ) inherits php {
 
   $real_install_options = $install_options ? {
     ''      => $php::install_options,
-    default => [],
+    default => $install_options,
   }
 
   if ( $install_package ) {

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -27,14 +27,14 @@
 class php::pear (
   $package         = $php::package_pear,
   $install_package = true,
-  $install_options = [],
+  $install_options = '',
   $version         = 'present',
   $path            = '/usr/bin:/usr/sbin:/bin:/sbin'
   ) inherits php {
 
   $real_install_options = $install_options ? {
-    []      => $php::install_options,
-    default => $install_options,
+    ''      => $php::install_options,
+    default => [],
   }
 
   if ( $install_package ) {

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -21,17 +21,27 @@
 #   Can be false if PEAR was already provided by another package or module.
 #   Default: true
 #
+# [*install_options*]
+#   An array of package manager install options. See $php::install_options
+#
 class php::pear (
   $package         = $php::package_pear,
   $install_package = true,
+  $install_options = [],
   $version         = 'present',
   $path            = '/usr/bin:/usr/sbin:/bin:/sbin'
   ) inherits php {
 
+  $real_install_options = $install_options ? {
+    []      => $php::install_options,
+    default => $install_options,
+  }
+
   if ( $install_package ) {
     package { 'php-pear':
-      ensure => $version,
-      name   => $package,
+      ensure          => $version,
+      name            => $package,
+      install_options => $real_install_options,
     }
   }
 

--- a/manifests/pear/module.pp
+++ b/manifests/pear/module.pp
@@ -7,6 +7,9 @@
 #   (default=true) - Tries to install pear module with the relevant OS package
 #   If set to "no" it installs the module via pear command
 #
+# [*install_options*]
+#   An array of package manager install options. See $php::install_options
+#
 # [*preferred_state*]
 #   (default="stable") - Define which preferred state to use when installing
 #   Pear modules via pear via command line (when use_package=false)
@@ -23,6 +26,7 @@
 define php::pear::module (
   $service             = '',
   $use_package         = true,
+  $install_options     = [],
   $preferred_state     = 'stable',
   $alldeps             = false,
   $version             = 'present',
@@ -88,13 +92,19 @@ define php::pear::module (
   }
   $package_name = "${real_module_prefix}${name}"
 
+  $real_install_options = $install_options ? {
+    []      => $php::install_options,
+    default => $install_options,
+  }
+
 
   case $bool_use_package {
     true: {
       package { "pear-${name}":
-        ensure  => $ensure,
-        name    => $package_name,
-        notify  => $real_service_autorestart,
+        ensure          => $ensure,
+        name            => $package_name,
+        install_options => $real_install_options,
+        notify          => $real_service_autorestart,
       }
     }
     default: {

--- a/manifests/pear/module.pp
+++ b/manifests/pear/module.pp
@@ -26,7 +26,7 @@
 define php::pear::module (
   $service             = '',
   $use_package         = true,
-  $install_options     = '',
+  $install_options     = [],
   $preferred_state     = 'stable',
   $alldeps             = false,
   $version             = 'present',
@@ -94,7 +94,7 @@ define php::pear::module (
 
   $real_install_options = $install_options ? {
     ''      => $php::install_options,
-    default => [],
+    default => $install_options,
   }
 
 

--- a/manifests/pear/module.pp
+++ b/manifests/pear/module.pp
@@ -26,7 +26,7 @@
 define php::pear::module (
   $service             = '',
   $use_package         = true,
-  $install_options     = [],
+  $install_options     = '',
   $preferred_state     = 'stable',
   $alldeps             = false,
   $version             = 'present',
@@ -93,8 +93,8 @@ define php::pear::module (
   $package_name = "${real_module_prefix}${name}"
 
   $real_install_options = $install_options ? {
-    []      => $php::install_options,
-    default => $install_options,
+    ''      => $php::install_options,
+    default => [],
   }
 
 

--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -42,7 +42,7 @@ define php::pecl::module (
   $service_autorestart = $php::bool_service_autorestart,
   $service             = $php::service,
   $use_package         = 'yes',
-  $install_options     = '',
+  $install_options     = [],
   $preferred_state     = 'stable',
   $auto_answer         = '\\n',
   $ensure              = present,
@@ -67,7 +67,7 @@ define php::pecl::module (
 
   $real_install_options = $install_options ? {
     ''      => $php::install_options,
-    default => [],
+    default => $install_options,
   }
 
   case $prefix {

--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -42,7 +42,7 @@ define php::pecl::module (
   $service_autorestart = $php::bool_service_autorestart,
   $service             = $php::service,
   $use_package         = 'yes',
-  $install_options     = [],
+  $install_options     = '',
   $preferred_state     = 'stable',
   $auto_answer         = '\\n',
   $ensure              = present,
@@ -66,8 +66,8 @@ define php::pecl::module (
   }
 
   $real_install_options = $install_options ? {
-    []      => $php::install_options,
-    default => $install_options,
+    ''      => $php::install_options,
+    default => [],
   }
 
   case $prefix {

--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -14,6 +14,9 @@
 #   Tries to install pecl module with the relevant package.
 #   If set to "no" it installs the module via pecl command. Default: true
 #
+# [*install_options*]
+#   An array of package manager install options. See $php::install_options
+#
 # [*preferred_state*]
 #   Define which preferred state to use when installing Pear modules via pecl
 #   command line (when use_package=no). Default: true
@@ -39,6 +42,7 @@ define php::pecl::module (
   $service_autorestart = $php::bool_service_autorestart,
   $service             = $php::service,
   $use_package         = 'yes',
+  $install_options     = [],
   $preferred_state     = 'stable',
   $auto_answer         = '\\n',
   $ensure              = present,
@@ -61,6 +65,11 @@ define php::pecl::module (
     undef   => undef,
   }
 
+  $real_install_options = $install_options ? {
+    []      => $php::install_options,
+    default => $install_options,
+  }
+
   case $prefix {
       false: {
         $real_package_name = $::operatingsystem ? {
@@ -77,9 +86,10 @@ define php::pecl::module (
   case $use_package {
     yes: {
       package { "php-${name}":
-        ensure => $ensure,
-        name   => $real_package_name,
-        notify => $manage_service_autorestart,
+        ensure          => $ensure,
+        name            => $real_package_name,
+        install_options => $real_install_options,
+        notify          => $manage_service_autorestart,
       }
     }
     default: {


### PR DESCRIPTION
This PR introduces a new `install_options` parameter to the classes and definitions that use the OS package manager, to support advanced package manager options without having to circumvent the puppet-php module.

The `install_options` package class parameter was added in [Puppet 3.6](https://docs.puppetlabs.com/puppet/3.6/reference/release_notes.html#package) and allows a very convenient advanced package manager option passing mechanism.

Examples of use cases for this feature:

- Adding a `--enablerepo` option to Yum to enable a repo to be sourced temporarily for the install of PHP
- Adding a `--no-install-recommends` option to Apt