### PR TITLE
Fix issue with timezone warning

### DIFF
--- a/lib/facter/php_fact_extension_dir.rb
+++ b/lib/facter/php_fact_extension_dir.rb
@@ -1,5 +1,5 @@
 Facter.add("php_fact_extension_dir") do
   setcode do
-    Facter::Util::Resolution.exec('php -i|grep \'^extension_dir\'|awk \'{ print $3 }\'')    || nil
+    Facter::Util::Resolution.exec('php -r "ini_alter(\'date.timezone\',\'UTC\'); phpinfo();"|grep \'^extension_dir\'|awk \'{ print $3 }\'')    || nil
   end
 end


### PR DESCRIPTION
This is what I get when I run puppet with the module:

```
==> default: PHP Warning:  Unknown: It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in Unknown on line 0
```

![capture d ecran 2015-03-14 a 10 12 33](https://cloud.githubusercontent.com/assets/671923/6651943/a63032b4-ca32-11e4-985a-849713ec65b1.png)
