### PR TITLE
Added default install options params to fix some bugs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,6 +97,7 @@ class php::params {
   $version = 'present'
   $service_autorestart = true
   $absent = false
+  $install_options = []
 
   ### General module variables that can have a site or per module default
   $puppi = false


### PR DESCRIPTION
Fixed bug with yum introduced by PR #81:

```
==> default: Error: Execution of '/bin/yum -d 0 -e 0 -y  list php' returned 1: No such command: . Please use /bin/yum --help
==> default: Error: /Stage[main]/Php/Package[php]/ensure: change from absent to present failed: Execution of '/bin/yum -d 0 -e 0 -y  list php' returned 1: No such command: . Please use /bin/yum --help
```

![capture d ecran 2015-03-14 a 11 42 54](https://cloud.githubusercontent.com/assets/671923/6652256/4677a91c-ca3f-11e4-8502-9d8537d8035f.png)
