### PR TITLE
future parser compatibility

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -54,7 +54,6 @@ define php::ini (
     }
 
   }else{
-
     file { "${config_dir}/${sapi_target}/conf.d/${target}":
       ensure  => 'present',
       content => template($template),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -222,13 +222,13 @@ class php (
     false => true,
   }
 
-  if ($php::source and $php::template) {
+  if ($php::source != '' and $php::template != '') {
     fail ('PHP: cannot set both source and template')
   }
-  if ($php::source and $php::bool_augeas) {
+  if ($php::source != '' and $php::bool_augeas) {
     fail ('PHP: cannot set both source and augeas')
   }
-  if ($php::template and $php::bool_augeas) {
+  if ($php::template != '' and $php::bool_augeas) {
     fail ('PHP: cannot set both template and augeas')
   }
 
@@ -269,7 +269,7 @@ class php (
   }
 
   # The whole php configuration directory can be recursively overriden
-  if $php::source_dir {
+  if $php::source_dir != ''{
     file { 'php.dir':
       ensure  => directory,
       path    => $php::config_dir,
@@ -286,7 +286,7 @@ class php (
 
 
   ### Include custom class if $my_class is set
-  if $php::my_class {
+  if $php::my_class != '' {
     include $php::my_class
   }
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -55,7 +55,7 @@ define php::module (
 
   include php
 
-  if $absent {
+  if $absent != '' {
     $real_version = 'absent'
   } else {
     $real_version = $version


### PR DESCRIPTION
Future parser evaluates "" as true, explicitly compare to empty string