### PR TITLE
php: fix php package installation resource name bug, introduced by #102.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -249,9 +249,8 @@ class php (
   }
 
   ### Managed resources
-  package { 'php':
+  package { $php::package:
     ensure          => $php::manage_package,
-    name            => $php::package,
     install_options => $php::install_options,
   }
 


### PR DESCRIPTION
php: fix php package installation resource name bug, introduced by #102.