### PR TITLE
Only enable/disable mods once (fixes #113)

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -44,12 +44,6 @@ define php::mod (
 
   include php
 
-  if $disable {
-    $php_mod_tool = 'php5dismod'
-  } else {
-    $php_mod_tool = 'php5enmod'
-  }
-
   $real_service_autorestart = $service_autorestart ? {
     true    => "Service[${php::service}]",
     false   => undef,
@@ -59,11 +53,21 @@ define php::mod (
     }
   }
 
-  exec { "php_mod_tool_${name}":
-    command => "${php_mod_tool} ${name}",
-    path    => $path,
-    notify  => $real_service_autorestart,
-    require => Package[$package],
+  if $disable {
+      exec { "php_mod_tool_disable_${name}":
+        command => "php5dismod ${name}",
+        path    => $path,
+        notify  => $real_service_autorestart,
+        require => Package[$package],
+        onlyif  => "php5query -M | grep -q '^${name}$'",
+      }
+  } else {
+      exec { "php_mod_tool_enable_${name}":
+        command => "php5enmod ${name}",
+        path    => $path,
+        notify  => $real_service_autorestart,
+        require => Package[$package],
+        unless  => "php5query -M | grep -q '^${name}$'",
+      }
   }
-
 }


### PR DESCRIPTION
Currently, puppet runs php5enmod or php5dismod every single puppet run, which triggers Apache to restart. Instead, check to make sure the mod is in the correct state. If it's not, then run the required commands to get the mod in the correct state.

Notes:
- I don't know of a clean way to only have 1 `exec` here, so I switched to two and gave them unique names to facilitate debugging. 
- It's possible to check if a module is enabled or not without the `grep`, however, the syntax is `php5query -s SAPI_NAME -m MOD_NAME` (`-s` is required). In the context of this code, (I assume) we do not know `SAPI_NAME`. I used `-M` instead, which returns all enabled modules, then `grep` for the one in question. 