### PR TITLE
Make ini files work on RedHat systems (fixes #94)

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -5,3 +5,5 @@ gem 'puppet', puppetversion, :require => false
 gem 'puppet-lint'
 gem 'rspec', '~> 3.1.0', :platforms => :ruby_18
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'json_pure', '2.0.1'
+gem 'rake', '~> 10.5.0'

--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -33,6 +33,8 @@ define php::ini (
 
   include php
 
+  $realservice_autorestart = $::php::realservice_autorestart
+
   $http_sapi = $::operatingsystem ? {
     /(?i:Ubuntu|Debian|Mint|SLES|OpenSuSE)/ => '/apache2/',
     default                                 => '/',
@@ -45,13 +47,13 @@ define php::ini (
       content => template($template),
       require => Package[$package],
       before  => File["${config_dir}/cli/conf.d/${target}"],
+      notify  => $realservice_autorestart,
     }
 
     file { "${config_dir}/cli/conf.d/${target}":
       ensure  => 'present',
       content => template($template),
       require => Package[$package],
-      notify  => Service[$service],
     }
 
   }else{
@@ -59,7 +61,7 @@ define php::ini (
       ensure  => 'present',
       content => template($template),
       require => Package[$package],
-      notify  => Service[$service],
+      notify  => $realservice_autorestart,
     }
 
   }

--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -40,30 +40,42 @@ define php::ini (
     default                                 => '/',
   }
 
-  if ($sapi_target == 'all') {
-
-    file { "${config_dir}${http_sapi}conf.d/${target}":
-      ensure  => 'present',
-      content => template($template),
-      require => Package[$package],
-      before  => File["${config_dir}/cli/conf.d/${target}"],
-      notify  => $realservice_autorestart,
+  case $::osfamily {
+    'RedHat' : {
+      file { "${config_dir}/${target}":
+        ensure  => 'present',
+        content => template($template),
+        require => Package[$php::package],
+        notify  => $realservice_autorestart,
+      }
     }
+    default : {
+      if ($sapi_target == 'all') {
 
-    file { "${config_dir}/cli/conf.d/${target}":
-      ensure  => 'present',
-      content => template($template),
-      require => Package[$package],
+        file { "${config_dir}${http_sapi}conf.d/${target}":
+          ensure  => 'present',
+          content => template($template),
+          require => Package[$package],
+          before  => File["${config_dir}/cli/conf.d/${target}"],
+          notify  => $realservice_autorestart,
+        }
+
+        file { "${config_dir}/cli/conf.d/${target}":
+          ensure  => 'present',
+          content => template($template),
+          require => Package[$package],
+        }
+
+      }else{
+        file { "${config_dir}/${sapi_target}/conf.d/${target}":
+          ensure  => 'present',
+          content => template($template),
+          require => Package[$package],
+          notify  => $realservice_autorestart,
+        }
+
+      }
     }
-
-  }else{
-    file { "${config_dir}/${sapi_target}/conf.d/${target}":
-      ensure  => 'present',
-      content => template($template),
-      require => Package[$package],
-      notify  => $realservice_autorestart,
-    }
-
   }
 
 }

--- a/spec/defines/php_ini_spec.rb
+++ b/spec/defines/php_ini_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe 'php::ini' do
+
+  let(:title) { 'php::ini' }
+  let(:node) { 'rspec.example42.com' }
+
+  context 'Test with restart' do
+    context 'On a Debian OS' do
+      let :facts do
+        {
+          :operatingsystem => 'Debian',
+        }
+      end
+
+      let :pre_condition do
+        [
+          'service { "apache2": }',
+          'class { "php": }',
+        ]
+      end
+
+      context 'with sapi_target all' do
+        let :params do
+          {
+            :name        => 'dynatrace',
+            :target      => 'dynatrace.ini',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/php5/apache2/conf.d/dynatrace.ini') }
+        it { is_expected.to contain_file('/etc/php5/cli/conf.d/dynatrace.ini') }
+
+        it { should contain_file('/etc/php5/apache2/conf.d/dynatrace.ini').that_notifies('Service[apache2]') }
+      end
+
+      context 'with sapi_target customsapi' do
+        let :params do
+          {
+            :name        => 'dynatrace',
+            :target      => 'dynatrace.ini',
+            :sapi_target => 'customsapi',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/php5/customsapi/conf.d/dynatrace.ini') }
+
+        it { should contain_file('/etc/php5/customsapi/conf.d/dynatrace.ini').that_notifies('Service[apache2]') }
+      end
+    end
+
+  end
+
+  context 'Test without restart' do
+    context 'On a Debian OS' do
+      let :facts do
+        {
+          :operatingsystem => 'Debian',
+        }
+      end
+
+      let :pre_condition do
+        [
+          'service { "apache2": }',
+          'class { "php": service_autorestart => false, }',
+        ]
+      end
+
+      context 'with sapi_target all' do
+        let :params do
+          {
+            :name        => 'dynatrace',
+            :target      => 'dynatrace.ini',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/php5/apache2/conf.d/dynatrace.ini') }
+        it { is_expected.to contain_file('/etc/php5/cli/conf.d/dynatrace.ini') }
+
+        it { should_not contain_file('/etc/php5/apache2/conf.d/dynatrace.ini').that_notifies('Service[apache2]') }
+      end
+
+      context 'with sapi_target customsapi' do
+        let :params do
+          {
+            :name        => 'dynatrace',
+            :target      => 'dynatrace.ini',
+            :sapi_target => 'customsapi',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/php5/customsapi/conf.d/dynatrace.ini') }
+
+        it { should_not contain_file('/etc/php5/customsapi/conf.d/dynatrace.ini').that_notifies('Service[apache2]') }
+
+      end
+    end
+  end
+
+end

--- a/spec/defines/php_ini_spec.rb
+++ b/spec/defines/php_ini_spec.rb
@@ -10,6 +10,7 @@ describe 'php::ini' do
       let :facts do
         {
           :operatingsystem => 'Debian',
+          :osfamily        => 'Debian',
         }
       end
 
@@ -51,6 +52,36 @@ describe 'php::ini' do
       end
     end
 
+    context 'On a RedHat OS' do
+      let :facts do
+        {
+          :operatingsystem => 'Redhat',
+          :osfamily        => 'RedHat',
+        }
+      end
+
+      let :pre_condition do
+        [
+          'service { "httpd": }',
+          'class { "php": }',
+        ]
+      end
+
+      context 'with defaults' do
+        let :params do
+          {
+            :name        => 'dynatrace',
+            :target      => 'dynatrace.ini',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/php.d/dynatrace.ini') }
+
+        it { should contain_file('/etc/php.d/dynatrace.ini').that_notifies('Service[httpd]') }
+      end
+
+    end
   end
 
   context 'Test without restart' do
@@ -58,6 +89,7 @@ describe 'php::ini' do
       let :facts do
         {
           :operatingsystem => 'Debian',
+          :osfamily        => 'Debian',
         }
       end
 
@@ -98,6 +130,37 @@ describe 'php::ini' do
         it { should_not contain_file('/etc/php5/customsapi/conf.d/dynatrace.ini').that_notifies('Service[apache2]') }
 
       end
+    end
+
+    context 'On a RedHat OS' do
+      let :facts do
+        {
+          :operatingsystem => 'Redhat',
+          :osfamily        => 'RedHat',
+        }
+      end
+
+      let :pre_condition do
+        [
+          'service { "httpd": }',
+          'class { "php": service_autorestart => false, }',
+        ]
+      end
+
+      context 'with defaults' do
+        let :params do
+          {
+            :name        => 'dynatrace',
+            :target      => 'dynatrace.ini',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/php.d/dynatrace.ini') }
+
+        it { should_not contain_file('/etc/php.d/dynatrace.ini').that_notifies('Service[httpd]') }
+      end
+
     end
   end
 


### PR DESCRIPTION
Hi,

This PR fixes #94 
It does however have a dependency on PR #117 and will pull it in when merged.

I do not have a SLES system to test regressions, I can verify Debian, RedHat and CentOS 7.

Regards,
Steven
